### PR TITLE
Update python3.cygport

### DIFF
--- a/python3.cygport
+++ b/python3.cygport
@@ -91,7 +91,7 @@ python36_CONTENTS="
 	usr/share/man/man1/python${slot}.1*
 	var/lib/rebase/dynpath.d/${NAME}
 "
-python36_devel_REQUIRES="python${slot/.}-setuptools"
+python36_devel_REQUIRES="python${slot/.}-setuptools libcrypt-devel"
 python36_devel_CONTENTS="
 	--exclude=usr/include/python${abi}/pyconfig.h
 	--exclude=${pyconfdir#/}/Makefile


### PR DESCRIPTION
Python headers require `crypt.h` from libcrypt-devel, per cygwinports/python2#1